### PR TITLE
remove unused final_delivery_days input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - (Keep your changes here until you have a release version)
 
+## [1.0.0] - 2023-05-03
+
+### Changed
+
+- Updated major version since this is released to customer
+
+### Removed
+
+- final_delivery_days input and references as this drove no output or workflows
+
 ## [0.2.1] - 2022-07-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tmcr",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tmcr",
-      "version": "0.2.1",
+      "version": "1.0.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmcr",
   "homepage": ".",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/Steps/TMDeliveryRequirementsS1000D.tsx
+++ b/src/Steps/TMDeliveryRequirementsS1000D.tsx
@@ -14,7 +14,6 @@ export const TMDeliveryRequirementsS1000D = () => {
         process_review_days: 0,
         verification_days: 0,
         prepub_review_days: 0,
-        final_delivery_days: 0,
       };
       dispatch({ type: "MERGE_OPTION", payload });
     }

--- a/src/Steps/TMDeliveryRequirementsS1000D.tsx
+++ b/src/Steps/TMDeliveryRequirementsS1000D.tsx
@@ -343,26 +343,7 @@ export const TMDeliveryRequirementsS1000D = () => {
                 <InputGroup.Text>Days</InputGroup.Text>
               </InputGroup>
             </td>
-            <td>
-              <InputGroup>
-                <Form.Control
-                  required
-                  type="number"
-                  min={minChecks.get("final_delivery")}
-                  value={
-                    globalState.wizardOptions[globalState.tmcrIndex]
-                      .final_delivery_days || 0
-                  }
-                  onChange={(e) =>
-                    dispatch({
-                      type: "MERGE_OPTION",
-                      payload: { final_delivery_days: e.target.value },
-                    })
-                  }
-                />
-                <InputGroup.Text>Days</InputGroup.Text>
-              </InputGroup>
-            </td>
+            <td></td>
             <td></td>
           </tr>
           <tr>


### PR DESCRIPTION
This input does not drive any outputs in the word doc, nor does it have any followon effects in the workflow.